### PR TITLE
Corrected module address in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module telego-questions
+module github.com/DeFaNy/telego-questions
 
 go 1.21
 


### PR DESCRIPTION
Updated the module address in the go.mod file, replacing "DeFaNy/telego-questions" with "github.com/DeFaNy/telego-questions". The module should now resolve correctly.