### PR TITLE
Corrected `import` in example.go

### DIFF
--- a/example.go
+++ b/example.go
@@ -8,7 +8,7 @@ import (
 	tu "github.com/mymmrac/telego/telegoutil"
 	"log"
 	"os"
-	qnmanager "telego-questions/manager"
+	qnmanager "github.com/DeFaNy/telego-questions/manager"
 )
 
 func main() {


### PR DESCRIPTION
Updated the `import` in the `example.go` file, replacing "DeFaNy/telego-questions" with "github.com/DeFaNy/telego-questions".